### PR TITLE
Localize post dates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ ruby RUBY_VERSION
 # Happy Jekylling!
 gem "jekyll", "3.3.1"
 gem "jekyll-paginate", "1.1.0"
+gem "i18n"
 
 # If you have any plugins, put them here!
 # group :jekyll_plugins do

--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,7 @@ baseurl: "" # the subpath of your site, e.g. /blog
 url: "http://lifelongstudent.io" # the base hostname & protocol for your site
 twitter_username: nirgn975
 github_username:  nirgn975
+lang: he
 
 # Build settings
 markdown: kramdown

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -12,7 +12,7 @@ layout: default
   <div class="post-content" itemprop="articleBody">
     <!-- Title and Date -->
     <header class="post-header">
-      <p class="post-meta"><time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">{{ page.date | date: "%b %-d, %Y" }}</time></p>
+      <p class="post-meta"><time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">{{ page.date | localize: ":long" }}</time></p>
       <h1 class="post-title" itemprop="name headline">{{ page.title }}</h1>
     </header>
 

--- a/_locales/he.yml
+++ b/_locales/he.yml
@@ -1,0 +1,198 @@
+he:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'האימות נכשל: %{errors}'
+  date:
+    abbr_day_names:
+    - א
+    - ב
+    - ג
+    - ד
+    - ה
+    - ו
+    - ש
+    abbr_month_names:
+    -
+    - ינו
+    - פבר
+    - מרץ
+    - אפר
+    - מאי
+    - יונ
+    - יול
+    - אוג
+    - ספט
+    - אוק
+    - נוב
+    - דצמ
+    day_names:
+    - ראשון
+    - שני
+    - שלישי
+    - רביעי
+    - חמישי
+    - שישי
+    - שבת
+    formats:
+      default: "%d-%m-%Y"
+      long: "%e ב%B, %Y"
+      short: "%e %b"
+    month_names:
+    -
+    - ינואר
+    - פברואר
+    - מרץ
+    - אפריל
+    - מאי
+    - יוני
+    - יולי
+    - אוגוסט
+    - ספטמבר
+    - אוקטובר
+    - נובמבר
+    - דצמבר
+    order:
+    - :day
+    - :month
+    - :year
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: בערך שעה אחת
+        other: בערך %{count} שעות
+      about_x_months:
+        one: בערך חודש אחד
+        other: בערך %{count} חודשים
+      about_x_years:
+        one: בערך שנה אחת
+        other: בערך %{count} שנים
+      almost_x_years:
+        one: כמעט שנה
+        other: כמעט %{count} שנים
+      half_a_minute: חצי דקה
+      less_than_x_minutes:
+        one: פחות מדקה אחת
+        other: פחות מ- %{count} דקות
+        zero: פחות מדקה אחת
+      less_than_x_seconds:
+        one: פחות משניה אחת
+        other: פחות מ- %{count} שניות
+        zero: פחות משניה אחת
+      over_x_years:
+        one: מעל שנה אחת
+        other: מעל %{count} שנים
+      x_days:
+        one: יום אחד
+        other: "%{count} ימים"
+      x_minutes:
+        one: דקה אחת
+        other: "%{count} דקות"
+      x_months:
+        one: חודש אחד
+        other: "%{count} חודשים"
+      x_seconds:
+        one: שניה אחת
+        other: "%{count} שניות"
+    prompts:
+      day: יום
+      hour: שעה
+      minute: דקה
+      month: חודש
+      second: שניות
+      year: שנה
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: חייב באישור
+      blank: לא יכול להיות ריק
+      confirmation: לא תואם לאישורו
+      empty: לא יכול להיות ריק
+      equal_to: חייב להיות שווה ל- %{count}
+      even: חייב להיות זוגי
+      exclusion: לא זמין
+      greater_than: חייב להיות גדול מ- %{count}
+      greater_than_or_equal_to: חייב להיות גדול או שווה ל- %{count}
+      inclusion: לא נכלל ברשימה
+      invalid: לא תקין
+      less_than: חייב להיות קטן מ- %{count}
+      less_than_or_equal_to: חייב להיות קטן או שווה ל- %{count}
+      not_a_number: חייב להיות מספר
+      not_an_integer: חייב להיות מספר שלם
+      odd: חייב להיות אי זוגי
+      taken: כבר בשימוש
+      too_long: ארוך מדי (יותר מ- %{count} תווים)
+      too_short: קצר מדי (פחות מ- %{count} תווים)
+      wrong_length: לא באורך הנכון (חייב להיות %{count} תווים)
+    template:
+      body: 'אנא בדוק את השדות הבאים:'
+      header:
+        one: 'לא ניתן לשמור את ה%{model}: שגיאה אחת'
+        other: 'לא ניתן לשמור את ה%{model}: %{count} שגיאות.'
+  helpers:
+    select:
+      prompt: נא לבחור
+    submit:
+      create: יצירת %{model}
+      submit: שמור %{model}
+      update: עדכון %{model}
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u %n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "₪"
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: מיליארד
+          million: מיליון
+          quadrillion: קודריליון
+          thousand: אלף
+          trillion: טריליון
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: בייט
+            other: בתים
+          gb: ג'יגה-בייט
+          kb: קילו-בייט
+          mb: מגה-בייט
+          tb: טרה-בייט
+    percentage:
+      format:
+        delimiter: ''
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: " ו"
+      two_words_connector: " ו"
+      words_connector: ", "
+  time:
+    am: am
+    formats:
+      default: "%a %d %b %H:%M:%S %Z %Y"
+      # long: "%d ב%B, %Y %H:%M" - includes hour
+      long: "%d ב%B, %Y"
+      short: "%d %b %H:%M"
+    pm: pm

--- a/_plugins/i18n_filter.rb
+++ b/_plugins/i18n_filter.rb
@@ -1,0 +1,28 @@
+require 'i18n'
+
+LOCALE = Jekyll.configuration({})['lang'] # set your locale from config var
+
+# Create folder "_locales" and put some locale file from https://github.com/svenfuchs/rails-i18n/tree/master/rails/locale
+module Jekyll
+  module I18nFilter
+    # Example:
+    #   {{ post.date | localize: "%d.%m.%Y" }}
+    #   {{ post.date | localize: ":short" }}
+    def localize(input, format=nil)
+      load_translations
+      format = (format =~ /^:(\w+)/) ? $1.to_sym : format
+      I18n.l input, :format => format
+    rescue
+      "error"
+    end
+
+    def load_translations
+      if I18n.backend.send(:translations).empty?
+        I18n.backend.load_translations Dir[File.join(File.dirname(__FILE__),'../_locales/*.yml')]
+        I18n.locale = LOCALE
+      end
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::I18nFilter)

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@ layout: default
     <div class="post-content">
       <div class="post-header">
         <h3><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h3>
-        <em>{{ post.date | date: "%b %-d, %Y" }}</em>
+        <em>{{ post.date | localize: ":long" }}</em>        
       </div>
       <p>{{ post.summary }}</p>
       <div class="post-action">

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@ layout: default
     <div class="post-content">
       <div class="post-header">
         <h3><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h3>
-        <em>{{ post.date | localize: ":long" }}</em>        
+        <em>{{ post.date | localize: ":long" }}</em>
       </div>
       <p>{{ post.summary }}</p>
       <div class="post-action">


### PR DESCRIPTION
I've added `i18n` and jekyll's `i18n_filter` plugin in order to localize the post dates from English to Hebrew.

Here's the result:
![image](https://cloud.githubusercontent.com/assets/13344923/21921811/817b4f24-d973-11e6-802e-09d0e77bc009.png)

Thanks for the great content. 🙏